### PR TITLE
fixed slider infinite, section height and background

### DIFF
--- a/client/src/components/Contact/Contact.css
+++ b/client/src/components/Contact/Contact.css
@@ -101,6 +101,7 @@
     align-self: center;
     margin-top: calc(41 * var(--proportion));
     border: none;
+    cursor: pointer;
 }
 
 @media only screen and (max-width: 1024px) {

--- a/client/src/components/Contact/Contact.jsx
+++ b/client/src/components/Contact/Contact.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect }  from 'react';
-import './Contact.css'
-import img from "./contact-img.png"
+import './Contact.css';
+import img from "./contact-img.png";
+import axios from 'axios';
 
 
 
@@ -12,12 +13,19 @@ function Contact() {
         menssage: '',
     })
     
-    const Submit = (e) => {
-
-        alert(form.name)
-        alert(form.email)
-        alert(form.about)
-        alert(form.menssage)
+    const Submit = async(e) => {
+       try {
+        e.preventDefault();
+        await axios.post('http://localhost:3001/api/sendmail', form)
+        setForm({
+            name: '',
+            email: '',
+            about: '',
+            menssage: '',
+        })
+       } catch (error) {
+           console.log(error)
+       }
     }
 
     return (

--- a/client/src/components/ExpertiseArea/ExpertiseArea.css
+++ b/client/src/components/ExpertiseArea/ExpertiseArea.css
@@ -16,7 +16,8 @@
     align-items: center;
     justify-content: space-between;
     width: 100vw;
-    height: calc(810 * var(--proportion));
+    height: calc(850 * var(--proportion));
+    padding-top: calc(150 * var(--proportion));
     overflow: hidden;
 }
 

--- a/client/src/components/PostToBlog/PostToBlog.css
+++ b/client/src/components/PostToBlog/PostToBlog.css
@@ -5,10 +5,11 @@
 
 .PostToBlog{
     background-image: url('./onda1 (1).svg');
-    height: calc( 800 * var(--proportion));
-    width: calc( 1920* var(--proportion));
+    height: calc( 430 * var(--proportion));
+    width: 100vw;
     background-repeat: no-repeat;
-    background-position-y: calc( 280 * var(--proportion));
+    background-position-y: calc( 150 * var(--proportion));
+    background-size: cover;
 }
 
 .PostToBlogSlick{

--- a/client/src/components/PostToBlog/PostToBlog.jsx
+++ b/client/src/components/PostToBlog/PostToBlog.jsx
@@ -34,7 +34,7 @@ function PostToBlog(){
     let settings = {
         arrows: true,
         dots: true,
-        infinite: true,
+        infinite: false,
         speed: 500,
         arrow: true,
         slidesToShow: 3,

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src" 
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
     "dotenv": "^8.2.0",
     "keystone": "^4.2.1",
     "mongoose": "^5.9.18",
+    "nodemailer": "^6.4.10",
     "underscore": "^1.9.1"
   },
   "devDependencies": {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,7 @@ const Footer = keystone.list('Footers');
 const About = keystone.list("AboutUs");
 const Testimony = keystone.list("Testimonies");
 const Value = keystone.list("Values");
+const nodemailer = require('nodemailer');
 
 
 
@@ -78,5 +79,39 @@ module.exports = (app) => {
     });
   });
 
+  app.post('/api/sendmail', (req, res) => {
+    const{
+      name,
+      email,
+      about,
+      menssage,
+    } = req.body;
+
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.TRANSPORTER_EMAIL,
+        pass: process.env.TRANSPORTER_PASSWORD,
+      },
+      tls: { rejectUnauthorized: false},
+    });
+    
+    const mailOptions = {
+      from: `"${name}" <${email}>`,
+      to: 'aquajr.onepage@gmail.com',
+      about,
+      text: `${name} <${email}> \n\n${menssage}`,
+    };
+    
+    transporter.sendMail(mailOptions, (error) => {
+      if (error) {
+        res.status(500).send(error);
+      } else {
+        res.status(200).send('Email enviado :)');
+      }
+    });
+  });
 };
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5660,6 +5660,11 @@ node.extend@~2.0.2:
     has "^1.0.3"
     is "^3.2.1"
 
+nodemailer@^6.4.10:
+  version "6.4.10"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.10.tgz#f4c8dc7991c57f41fd081bef224ef01f7065143d"
+  integrity sha512-j+pS9CURhPgk6r0ENr7dji+As2xZiHSvZeVnzKniLOw1eRAyM/7flP0u65tCnsapV8JFu+t0l/5VeHsCZEeh9g==
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"


### PR DESCRIPTION
## What I did
- Fixed the Post to Blog slider (no longer infinite)
- Fix the Post to Blog background, it now extends beyond 1920px
- Fixed the spacing between the Banner, Post to Blog and Expertise Area sections
- Made the backend for the Contact Us section

## How to test
- Access the branch through your terminal (you must be up to date with **develop** in order to do that)
- Run both **yarn start** and **nodemon index.js**
- Access the **localhost3000** window on your browser
- Check if one of the tracking circles on the Post to Blog slider is automatically blue
- Stretch the width of the page beyond 1920px and check if the Post to Blog background will fill it
- Pay attention to the spacing between the first three sections (Banner, Post to Blog and Expertise Area) on both the web and mobile version and check if it looks just like the mockup
- Send a message through the Contact Us section, access the Aqua-Jr Gmail (login and password are available on my Send Emil notion card) and check if your message arrived.
